### PR TITLE
fix: disable persist-credentials in checkout to avoid auth conflicts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,6 @@ jobs:
           output-modes: npm
 
       - name: Publish to Artifactory npm-public
-        run: npm publish --userconfig=./.npmrc-public --@lexicographic:registry="https://packages.atlassian.com/api/npm/npm-public/"
+        run: npm publish
+        env:
+          NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc-public


### PR DESCRIPTION
Mirrors the pattern in atlassian-labs/compiled to avoid GITHUB_TOKEN credential conflicts with artifact-publish-token.